### PR TITLE
Remove useless txt='' and share md5 function more wisely

### DIFF
--- a/md5.js
+++ b/md5.js
@@ -113,7 +113,6 @@
 		if (/[\x80-\xFF]/.test(s)) {
 			s = unescape(encodeURI(s));
 		}
-		txt = '';
 		var n = s.length, state = [1732584193, -271733879, -1732584194, 271733878], i;
 		for (i = 64; i <= s.length; i += 64) {
 			md5cycle(state, md5blk(s.substring(i - 64, i)));
@@ -159,7 +158,13 @@
 		return x.join('');
 	}
 
-	md5 = function (s) {
+	var exports = this;
+	if (typeof module !== "undefined")
+		exports = module;
+	else if (typeof window !== "undefined")
+		exports = window;
+
+	exports.md5 = function (s) {
 		return hex(md51(s));
 	}
 


### PR DESCRIPTION
This commit has no breaking changes. md5.js still can be used in browser, but now it is also strict mode compatible. CommonJS support is a little bonus.
